### PR TITLE
feat: Add report page to display budget planner data

### DIFF
--- a/assets/css/report.css
+++ b/assets/css/report.css
@@ -1,0 +1,107 @@
+/* General Report Styles */
+#report-content {
+  padding: 2rem;
+  background-color: #ffffff;
+}
+
+#report-content .stats-card {
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#report-content .stats-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 12px rgba(0, 0, 0, 0.1);
+}
+
+#report-content .stats-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+#report-content .stats-label {
+  font-size: 1rem;
+  color: #6c757d;
+  margin-top: 0.5rem;
+}
+
+#report-content .table {
+  margin-top: 2rem;
+}
+
+#report-content .table th {
+  background-color: var(--primary-color);
+  color: #ffffff;
+  font-weight: 600;
+}
+
+/* Print-Specific Styles */
+@media print {
+  body,
+  #wrapper,
+  #page-content-wrapper {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    font-size: 12pt;
+  }
+
+  #sidebar-wrapper,
+  #menu-toggle,
+  .navbar,
+  #printReportBtn,
+  .card-header-custom .btn {
+    display: none !important;
+  }
+
+  #page-content-wrapper {
+    padding: 0 !important;
+  }
+
+  .card {
+    border: none !important;
+    box-shadow: none !important;
+  }
+
+  .card-header,
+  .card-body {
+    padding: 0 !important;
+  }
+
+  #report-content {
+    padding: 1cm;
+  }
+
+  .table-responsive {
+    overflow: visible;
+  }
+
+  .table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .table th,
+  .table td {
+    border: 1px solid #dee2e6 !important;
+    padding: 0.5rem;
+  }
+
+  .table th {
+    background-color: #343a40 !important;
+    color: #ffffff !important;
+    -webkit-print-color-adjust: exact; /* Chrome, Safari */
+    color-adjust: exact; /* Firefox */
+  }
+
+  .stats-card {
+    page-break-inside: avoid;
+  }
+}

--- a/assets/js/report.js
+++ b/assets/js/report.js
@@ -1,0 +1,102 @@
+document.addEventListener("DOMContentLoaded", function () {
+  // Event listener for the print button
+  const printButton = document.getElementById("printReportBtn");
+  if (printButton) {
+    printButton.addEventListener("click", function () {
+      const reportContent = document.getElementById("report-content").innerHTML;
+      const originalContent = document.body.innerHTML;
+      document.body.innerHTML = reportContent;
+      window.print();
+      document.body.innerHTML = originalContent;
+      // Re-initialize event listeners if needed
+      // This is a simple approach; a more robust solution might be needed for complex pages
+      location.reload();
+    });
+  }
+});
+
+function displayReport(results) {
+  const reportContent = document.getElementById("report-content");
+  const noDataMessage = document.getElementById("no-report-data");
+
+  if (!results || results.length === 0 || !results.schedule || results.schedule.length === 0) {
+    reportContent.innerHTML = ""; // Clear previous report
+    reportContent.appendChild(noDataMessage);
+    noDataMessage.style.display = "block";
+    return;
+  }
+
+  noDataMessage.style.display = "none";
+
+  // Format currency function
+  const formatCurrency = (amount) =>
+    new Intl.NumberFormat("en-NG", {
+      style: "currency",
+      currency: "NGN",
+    }).format(amount);
+
+  // Report structure
+  const reportHTML = `
+    <div class="row mb-4">
+      <div class="col-md-3">
+        <div class="stats-card">
+          <div class="stats-value">${formatCurrency(results.projectCost)}</div>
+          <div class="stats-label">Target Amount</div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="stats-card">
+          <div class="stats-value">${formatCurrency(results.totalContributions)}</div>
+          <div class="stats-label">Total Contributions</div>
+        </div>
+      </div>
+      <div class="col-md-3">
+        <div class="stats-card">
+          <div class="stats-value">${formatCurrency(results.totalInterest)}</div>
+          <div class="stats-label">Total Interest</div>
+        </div>
+      </div>
+       <div class="col-md-3">
+        <div class="stats-card">
+          <div class="stats-value">${formatCurrency(results.finalBalance)}</div>
+          <div class="stats-label">Final Balance</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped table-hover">
+        <thead class="table-dark">
+          <tr>
+            <th>Period</th>
+            <th>Date</th>
+            <th>Contribution</th>
+            <th>Interest Earned</th>
+            <th>Ending Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${results.schedule
+            .map(
+              (item) => `
+            <tr>
+              <td>${item.period}</td>
+              <td>${item.date.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+              })}</td>
+              <td>${formatCurrency(item.contribution)}</td>
+              <td>${formatCurrency(item.interest)}</td>
+              <td>${formatCurrency(item.balance)}</td>
+            </tr>
+          `
+            )
+            .join("")}
+        </tbody>
+      </table>
+    </div>
+  `;
+
+  reportContent.innerHTML = reportHTML;
+}

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="assets/css/style.css" />
+    <link rel="stylesheet" href="assets/css/report.css" />
   </head>
   <body>
     <div class="d-flex" id="wrapper">
@@ -323,7 +324,27 @@
 
           <!-- Other Sections -->
           <div id="reports" class="section fade-in" style="display: none">
-            <h4>Reports Section</h4>
+            <div class="card card-custom">
+              <div class="card-header card-header-custom d-flex justify-content-between align-items-center">
+                <h3 class="mb-0">
+                  <i class="fas fa-chart-bar me-2"></i>Financial Report
+                </h3>
+                <button class="btn btn-sm btn-outline-secondary" id="printReportBtn">
+                  <i class="fas fa-print me-2"></i>Print Report
+                </button>
+              </div>
+              <div class="card-body" id="report-content">
+                <div class="text-center p-5" id="no-report-data">
+                  <i class="fas fa-search-dollar fa-3x text-muted mb-3"></i>
+                  <h4 class="text-muted">No report data available.</h4>
+                  <p>
+                    Please calculate a sinking fund in the
+                    <a href="#" onclick="showSection('budget-planner')">Budget Planner</a>
+                    to generate a report.
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
           <div id="settings" class="section fade-in" style="display: none">
             <h4>Settings Section</h4>
@@ -337,6 +358,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="assets/js/data.js"></script>
+    <script src="assets/js/report.js"></script>
     <script>
       // Global variables
       let calculationResults = [];
@@ -377,6 +399,8 @@
 
         if (sectionId === "dashboard") {
           updateDashboard();
+        } else if (sectionId === "reports") {
+          displayReport(calculationResults);
         }
       }
 


### PR DESCRIPTION
This commit introduces a new 'Reports' section to the application.

The new report page displays the detailed sinking fund schedule and a summary of the financial calculations performed in the 'Budget Planner' section.

Key changes:
- Added a new 'Reports' section to `index.html` with a structured layout.
- Created `assets/js/report.js` to handle the logic for populating the report with data and a print-to-PDF functionality.
- Created `assets/css/report.css` to provide custom styling for the report, including print-friendly styles.
- Integrated the new JavaScript and CSS files into `index.html`.
- Updated the application's navigation logic to display the report when the 'Reports' section is selected.